### PR TITLE
Support run from windows

### DIFF
--- a/py_dev_container_template.py
+++ b/py_dev_container_template.py
@@ -54,7 +54,7 @@ for source, target in FILES_TO_COPY:
         files_to_mutate.append(f)
 
 for f in files_to_mutate:
-    incoming = f.read_text()
-    outgoing = incoming.replace("<<WORKSPACE DIRECTORY>>", str(workspace_directory))
-    outgoing = outgoing.replace("<<PROJECT NAME>>", project_name)
+    incoming = f.read_bytes()
+    outgoing = incoming.replace(b"<<WORKSPACE DIRECTORY>>", str(workspace_directory).encode("utf-8"))
+    outgoing = outgoing.replace(b"<<PROJECT NAME>>", project_name.encode("utf-8"))
     f.write_text(outgoing)

--- a/py_dev_container_template.py
+++ b/py_dev_container_template.py
@@ -57,4 +57,4 @@ for f in files_to_mutate:
     incoming = f.read_bytes()
     outgoing = incoming.replace(b"<<WORKSPACE DIRECTORY>>", str(workspace_directory).encode("utf-8"))
     outgoing = outgoing.replace(b"<<PROJECT NAME>>", project_name.encode("utf-8"))
-    f.write_text(outgoing)
+    f.write_bytes(outgoing)


### PR DESCRIPTION
Fix windows adding CRLF which causes the unix container to choke.

The path will also be wrong for the workspace folder but its an obvious fix that occurs prior to the container starting